### PR TITLE
Fix incorrect pipeline configs for initial testing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,40 +6,20 @@ on:
       - 'nvdclient/**.py'
 
 jobs:
-  mypy:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: x64
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Install mypy
-        run: pip install mypy
-      - name: Run mypy
-        uses: sasanquaneuf/mypy-github-action@releases/v1
-        with:
-          checkName: 'mypy'   # NOTE: this needs to be the same as the job name
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   black:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.12"]
     steps:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
+      - name: info
+        run: pwd && ls -lah
       - uses: psf/black@stable
         with:
           options: "--check --verbose"
-          src: "./nvdclient"
+          src: "nvdclient/"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,5 +23,7 @@ jobs:
         run: |
           python -m pip install --upgrade poetry
           python -m poetry install --with tests
+      - name: info
+        run: pwd && ls -lah
       - name: Test with unittest
         run: python -m unittest discover tests/


### PR DESCRIPTION
Presently the configurations for linting and testing via Github Actions rely on invalid assumptions about the Actions environment. These must be corrected so that the pipelines pass for correct code.