### PR TITLE
Add workflow permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Add the permissions key to the job or the root of workflow (in this case it is applied to all jobs in the workflow that do not have their own permissions key) and assign the least privileges required to complete the task.

As detected by Github Code Scanning alerts, implementing suggested fix.